### PR TITLE
Add support for collections in Minimum/MaximumLengthRules

### DIFF
--- a/lib/src/rules/length.dart
+++ b/lib/src/rules/length.dart
@@ -1,6 +1,7 @@
 import '../super_form.dart';
 
-/// Ensures that given [String] value length is greater or equal than given [length].
+/// Ensures that given [String], [Iterable] (List, Set) or [Map] value length
+/// is greater or equal than given [length].
 class MinimumLengthRule extends SuperFormFieldRule {
   final int length;
   final String message;
@@ -9,14 +10,21 @@ class MinimumLengthRule extends SuperFormFieldRule {
 
   @override
   ValidationError? validate(dynamic value) {
+    if (value is Iterable && value.length < length) {
+      return ValidationError(message);
+    }
     if (value is String && value.length < length) {
+      return ValidationError(message);
+    }
+    if (value is Map && value.length < length) {
       return ValidationError(message);
     }
     return null;
   }
 }
 
-/// Ensures that given [String] value length is less or equal than given [length].
+/// Ensures that given [String], [Iterable] (List, Set) or [Map] value length
+/// is less or equal than given [length].
 class MaximumLengthRule extends SuperFormFieldRule {
   final int length;
   final String message;
@@ -25,7 +33,13 @@ class MaximumLengthRule extends SuperFormFieldRule {
 
   @override
   ValidationError? validate(dynamic value) {
+    if (value is Iterable && value.length > length) {
+      return ValidationError(message);
+    }
     if (value is String && value.length > length) {
+      return ValidationError(message);
+    }
+    if (value is Map && value.length > length) {
       return ValidationError(message);
     }
     return null;

--- a/test/rules/length_test.dart
+++ b/test/rules/length_test.dart
@@ -12,6 +12,14 @@ const maxLengthTestCases = [
   ParamRuleTestCase("1", 0, false),
   ParamRuleTestCase("", -1, false),
   ParamRuleTestCase("", 1000, true),
+  ParamRuleTestCase([1, 2, 3], 3, true),
+  ParamRuleTestCase([1, 2, 3], 2, false),
+  ParamRuleTestCase([], 0, true),
+  ParamRuleTestCase([], -1, false),
+  ParamRuleTestCase({}, 0, true),
+  ParamRuleTestCase({}, -1, false),
+  ParamRuleTestCase({"one": 1}, 1, true),
+  ParamRuleTestCase({"one": 1}, 0, false),
 ];
 
 const minLengthTestCases = [
@@ -23,6 +31,14 @@ const minLengthTestCases = [
   ParamRuleTestCase("1", 0, true),
   ParamRuleTestCase("", -1, true),
   ParamRuleTestCase("", 1000, false),
+  ParamRuleTestCase([1, 2, 3], 3, true),
+  ParamRuleTestCase([1, 2, 3], 4, false),
+  ParamRuleTestCase([], 0, true),
+  ParamRuleTestCase([], -1, true),
+  ParamRuleTestCase({}, 0, true),
+  ParamRuleTestCase({}, -1, true),
+  ParamRuleTestCase({"one": 1}, 1, true),
+  ParamRuleTestCase({"one": 1}, 2, false),
 ];
 
 void main() {


### PR DESCRIPTION
Turns out Map and String are not Iterable, but that's not a problem.

Closes #3 