### PR TITLE
Prevent TextField onChange validation being triggered on first focus

### DIFF
--- a/lib/src/fields/text_super_form_field.dart
+++ b/lib/src/fields/text_super_form_field.dart
@@ -239,7 +239,7 @@ class _TextSuperFormFieldState extends SuperFormFieldState {
       return;
     }
 
-    if (currentFieldData.value != _controller?.text) {
+    if ((currentFieldData.value ?? "") != _controller?.text) {
       SuperFormFieldData newData = currentFieldData.copyWithValue(
           value: _controller?.text, touched: true);
 

--- a/test/fields/text_super_form_field_test.dart
+++ b/test/fields/text_super_form_field_test.dart
@@ -120,6 +120,10 @@ void main() {
       ),
     );
 
+    await tester.tap(find.byKey(inputKey));
+    await tester.pump();
+    expect(find.text(errorText), findsNothing);
+
     await tester.enterText(find.byKey(inputKey), "hello");
     await tester.pump();
     expect(find.text(errorText), findsOneWidget);

--- a/test/super_form_test.dart
+++ b/test/super_form_test.dart
@@ -283,7 +283,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(formKey.currentState!.values["login"], "hellothere");
-    expect(formKey.currentState!.values["password"], isEmpty);
+    expect(formKey.currentState!.values["password"], isNull);
     expect(formKey.currentState!.errors["login"], isEmpty);
     expect(formKey.currentState!.errors["password"], isEmpty);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Got it in example - SignUp form. I did find the overall danger of this happening, but I didn't expect it to come onFocus 🤔 

This is also preventing the form from setting up empty String as value.
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
