### PR TITLE
Set field as touched when it loses focus

### DIFF
--- a/lib/src/fields/text_super_form_field.dart
+++ b/lib/src/fields/text_super_form_field.dart
@@ -84,21 +84,7 @@ class TextSuperFormField extends SuperFormField {
     ScrollController? scrollController,
     Widget? noFormFallback,
     FocusNode? focusNode,
-  })  : assert(obscuringCharacter.length == 1),
-        assert(maxLines == null || maxLines > 0),
-        assert(minLines == null || minLines > 0),
-        assert(
-          (maxLines == null) || (minLines == null) || (maxLines >= minLines),
-          "minLines can't be greater than maxLines",
-        ),
-        assert(
-          !expands || (maxLines == null && minLines == null),
-          'minLines and maxLines must be null when expands is true.',
-        ),
-        assert(!obscureText || maxLines == 1,
-            'Obscured fields cannot be multiline.'),
-        assert(maxLength == null || maxLength > 0),
-        super(
+  }) : super(
           key: key,
           name: name,
           rules: rules ?? const [],

--- a/lib/src/super_form_field.dart
+++ b/lib/src/super_form_field.dart
@@ -175,6 +175,10 @@ class SuperFormFieldState extends State<SuperFormField> {
       if (focused) {
         focused = false;
 
+        if (data?.touched == false) {
+          setTouched(true);
+        }
+
         if (form?.validationMode == ValidationMode.onBlur) {
           validate(markSubmitted: true);
         }

--- a/test/fields/text_super_form_field_test.dart
+++ b/test/fields/text_super_form_field_test.dart
@@ -74,6 +74,8 @@ void main() {
     await tester.pump();
     expect(find.text(errorText), findsOneWidget);
 
+    expect(formKey.currentState!.data["name"]!.touched, true);
+
     await tester.enterText(find.byKey(inputKey), "hello world");
     await tester.pump();
     expect(find.text(errorText), findsNothing);


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
Made field set themselves as touched after they lose focus. This isn't really common, especially on mobile devices, but could be useful for desktop environments.

<!--- Describe your changes in detail -->
Also removed assertions from TextSuperFormField. It is extremely stupid having to check these every Flutter release and they don't provide any real benefits. Added test for un-registering field that is still active.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
