### PR TITLE
Fix validation error to actually not extend Dart's Error class

### DIFF
--- a/lib/src/super_form.dart
+++ b/lib/src/super_form.dart
@@ -756,15 +756,18 @@ class _RestorableSuperFormValues extends RestorableValue<Map> {
   Object? toPrimitives() => value;
 }
 
-class ValidationError extends Error {
+class ValidationError extends Equatable {
   final String message;
 
-  ValidationError(this.message);
+  const ValidationError(this.message);
 
   @override
   String toString() {
-    return 'ValidationError: "$message"';
+    return 'Validation error: $message';
   }
+
+  @override
+  List<Object?> get props => [message];
 }
 
 abstract class SuperFormFieldRule<T> {

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -210,4 +210,17 @@ void main() {
     verify(listener(formKey.currentState!.values)).called(1);
     verifyNoMoreInteractions(listener);
   });
+
+  test("ValidationError.toString", () {
+    const error = ValidationError("Must be a number!");
+
+    expect(error.toString(), "Validation error: Must be a number!");
+  });
+
+  test("ValidationError implements hashCode/equals", () {
+    const error = ValidationError("Must be a number!");
+    const error2 = ValidationError("Must be a number!");
+
+    expect(error == error2, true);
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
It was a mistake to use Dart "Error" as a base class. It isn't meant to be used like that. Exception would be better but I don't think it is good.

I was thinking about renaming the ValidationError to ValidationFailure since this is actually more meaningful - the validation did well, but the result is a failure. One argument against that is that most people (or at least I think so) are familiar with `errors`.
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
