### PR TITLE
Refactor/rules handling

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -174,7 +174,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -230,7 +230,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.0.0"

--- a/lib/src/fields/checkbox_super_form_field.dart
+++ b/lib/src/fields/checkbox_super_form_field.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:super_form/super_form.dart';
 
 /// A pair of value and optional label for a single checkbox.

--- a/lib/src/fields/checkbox_super_form_field.dart
+++ b/lib/src/fields/checkbox_super_form_field.dart
@@ -171,7 +171,7 @@ class CheckboxSuperFormField<T> extends SuperFormField {
               // If the field was tried to be submitted it should be now revalidated every change
               if (formState.validationMode == ValidationMode.onChange ||
                   newData.submitted) {
-                newData = newData.validate();
+                newData = newData.validate(rules ?? []);
               }
 
               formState.updateFieldData(newData);
@@ -253,7 +253,7 @@ class CheckboxSuperFormField<T> extends SuperFormField {
               // If the field was tried to be submitted it should be now revalidated every change
               if (formState.validationMode == ValidationMode.onChange ||
                   newData.submitted) {
-                newData = newData.validate();
+                newData = newData.validate(rules ?? []);
               }
 
               formState.updateFieldData(newData);

--- a/lib/src/fields/dropdown_super_form_field.dart
+++ b/lib/src/fields/dropdown_super_form_field.dart
@@ -109,7 +109,7 @@ class DropdownSuperFormField<T> extends SuperFormField {
                               if (formState.validationMode ==
                                       ValidationMode.onChange ||
                                   newData.submitted) {
-                                newData = newData.validate();
+                                newData = newData.validate(rules ?? []);
                               }
 
                               formState.updateFieldData(newData);

--- a/lib/src/fields/radio_super_form_field.dart
+++ b/lib/src/fields/radio_super_form_field.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:super_form/super_form.dart';
 
 /// A pair of value and optional label for a single radio.

--- a/lib/src/fields/radio_super_form_field.dart
+++ b/lib/src/fields/radio_super_form_field.dart
@@ -147,7 +147,7 @@ class RadioSuperFormField<T> extends SuperFormField {
               // If the field was tried to be submitted it should be now revalidated every change
               if (formState.validationMode == ValidationMode.onChange ||
                   newData.submitted) {
-                newData = newData.validate();
+                newData = newData.validate(rules ?? []);
               }
 
               formState.updateFieldData(newData);
@@ -215,7 +215,7 @@ class RadioSuperFormField<T> extends SuperFormField {
               // If the field was tried to be submitted it should be now revalidated every change
               if (formState.validationMode == ValidationMode.onChange ||
                   newData.submitted) {
-                newData = newData.validate();
+                newData = newData.validate(rules ?? []);
               }
 
               formState.updateFieldData(newData);

--- a/lib/src/fields/slider_super_form_field.dart
+++ b/lib/src/fields/slider_super_form_field.dart
@@ -187,7 +187,7 @@ class SliderSuperFormField extends SuperFormField {
               // If the field was tried to be submitted it should be now revalidated every change
               if (formState.validationMode == ValidationMode.onChange ||
                   newData.submitted) {
-                newData = newData.validate();
+                newData = newData.validate(rules ?? []);
               }
 
               formState.updateFieldData(newData);

--- a/lib/src/fields/text_super_form_field.dart
+++ b/lib/src/fields/text_super_form_field.dart
@@ -113,7 +113,7 @@ class TextSuperFormField extends SuperFormField {
                   onEditingComplete();
                 }
 
-                final validated = fieldData.validate();
+                final validated = fieldData.validate(rules ?? []);
                 if (validated.errors.isEmpty) {
                   fieldState.focusNode.nextFocus();
                 }
@@ -234,7 +234,7 @@ class _TextSuperFormFieldState extends SuperFormFieldState {
       // If the field was tried to be submitted it should be now revalidated every change
       if (form?.validationMode == ValidationMode.onChange ||
           currentFieldData.submitted) {
-        newData = newData.validate();
+        newData = newData.validate(widget.rules);
       }
 
       SuperForm.ofFieldMaybe(context, currentFieldData.name)

--- a/lib/src/super_form_field.dart
+++ b/lib/src/super_form_field.dart
@@ -131,7 +131,7 @@ class SuperFormFieldState extends State<SuperFormField> {
       data = form?.data[widget.name];
 
       if (data != null) {
-        form?.updateFieldData(data!.copyWith(rules: widget.rules));
+        form?.updateFieldRules(widget.name, widget.rules);
 
         if (data?.submitted ?? false) {
           validate();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -185,7 +185,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   typed_data:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   watcher:
     dependency: transitive
     description:

--- a/test/debug_properties_test.dart
+++ b/test/debug_properties_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_form/super_form.dart';
 

--- a/test/exceptional_test.dart
+++ b/test/exceptional_test.dart
@@ -34,10 +34,11 @@ void main() {
         () => key.currentState?.updateFieldData(const SuperFormFieldData(
             name: "hello",
             value: true,
-            rules: [],
             touched: true,
             errors: [],
             submitted: false)),
+        throwsStateError);
+    expect(() => key.currentState?.updateFieldRules("hello", []),
         throwsStateError);
   });
 

--- a/test/exceptional_test.dart
+++ b/test/exceptional_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_form/super_form.dart';
 

--- a/test/exceptional_test.dart
+++ b/test/exceptional_test.dart
@@ -5,11 +5,11 @@ import 'package:super_form/super_form.dart';
 import 'utils.dart';
 
 void main() {
-  testWidgets('Empty form does not crash', (WidgetTester tester) async {
+  testWidgets('empty form does not crash', (WidgetTester tester) async {
     await tester.pumpWidget(const SuperForm(child: SizedBox()));
   });
 
-  testWidgets('Empty form with key does not crash',
+  testWidgets('empty form with key does not crash',
       (WidgetTester tester) async {
     final key = GlobalKey<SuperFormState>();
 
@@ -18,7 +18,7 @@ void main() {
     expect(key.currentState?.data.length, 0);
   });
 
-  testWidgets('Actions on unregistered field throws StateError',
+  testWidgets('actions on unregistered field throws StateError',
       (WidgetTester tester) async {
     final key = GlobalKey<SuperFormState>();
 
@@ -41,7 +41,7 @@ void main() {
         throwsStateError);
   });
 
-  testWidgets('Calls .of without ancestor throws', (WidgetTester tester) async {
+  testWidgets('calls .of without ancestor throws', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(
       child: Builder(
         builder: (context) => OutlinedButton(
@@ -58,7 +58,7 @@ void main() {
     expect(tester.takeException(), isInstanceOf<FlutterError>());
   });
 
-  testWidgets('Rogue text field does not crash', (WidgetTester tester) async {
+  testWidgets('rogue text field does not crash', (WidgetTester tester) async {
     await tester.pumpWidget(boilerplate(
       child: TextSuperFormField(name: "hello_there"),
     ));

--- a/test/infinite_rendering_test.dart
+++ b/test/infinite_rendering_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:super_form/super_form.dart';
+
+import 'utils.dart';
+
+class InfiniteRenderingCase extends StatelessWidget {
+  const InfiniteRenderingCase({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SuperForm(
+        child: Column(
+      children: [
+        Builder(builder: (context) {
+          SuperForm.ofField(context, "field");
+
+          return TextSuperFormField(
+            name: "field",
+            rules: [RequiredRule("Can't be empty")],
+          );
+        })
+      ],
+    ));
+  }
+}
+
+void main() {
+  testWidgets('renders in finite amount of frames',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(boilerplate(child: const InfiniteRenderingCase()));
+
+    await tester.pumpAndSettle();
+  });
+}

--- a/test/super_form_error_text_test.dart
+++ b/test/super_form_error_text_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:super_form/super_form.dart';
 

--- a/test/super_form_test.dart
+++ b/test/super_form_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:super_form/super_form.dart';

--- a/test/super_form_test.dart
+++ b/test/super_form_test.dart
@@ -732,5 +732,9 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text("Minimum 3"), findsNothing);
+    expect(
+        formKey.currentState!.rules["virtual"],
+        predicate<List>((rules) =>
+            rules[0] is MinValueRule && (rules[0] as MinValueRule).min == 1));
   });
 }

--- a/test/super_form_test.dart
+++ b/test/super_form_test.dart
@@ -696,4 +696,41 @@ void main() {
     formKey.currentState!.setTouched("login", true);
     expect(formKey.currentState!.data["login"]!.touched, true);
   });
+
+  testWidgets('can update rules programatically', (WidgetTester tester) async {
+    final formKey = GlobalKey<SuperFormState>();
+
+    await tester.pumpWidget(
+      boilerplate(
+        child: SuperForm(
+          key: formKey,
+          child: Builder(
+            builder: (context) =>
+                Column(children: const [SuperFormErrorText(name: "virtual")]),
+          ),
+        ),
+      ),
+    );
+
+    formKey.currentState!
+        .register(name: "virtual", rules: [MinValueRule(3, "Minimum 3")]);
+    formKey.currentState!.setValue("virtual", "a");
+    formKey.currentState!.validate("virtual");
+    await tester.pumpAndSettle();
+
+    expect(find.text("Minimum 3"), findsOneWidget);
+
+    formKey.currentState!.updateFieldRules(
+      "virtual",
+      [MinValueRule(1, "Minimum 1")],
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text("Minimum 3"), findsOneWidget);
+
+    formKey.currentState!.validate("virtual");
+    await tester.pumpAndSettle();
+
+    expect(find.text("Minimum 3"), findsNothing);
+  });
 }

--- a/test/validation_test.dart
+++ b/test/validation_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:super_form/super_form.dart';


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description
The problem with rules is that it is impossible to figure out if rules have actually been changed between builds and because rules have been a part of field data it was considered as a change for that field. 

This allowed to easily get into an infinite rendering loop.

This PR will separate field rules from field data, thus providing the ability to prevent unnecessary build triggers and ignore rules changes since those are not actually needed for rendering and are not really a part of the state either.

Updating rules by programmatically on SuperForm instance never made much sense for fields that have their widgets so there is no need to implement listening on that. If there would be a need for that it would probably be exposed via `onRulesChange` callback similar to `onChange`

Consider this bug fix as a minor breaking change.
<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
